### PR TITLE
Switch timesheet OCR to AWS Textract

### DIFF
--- a/FieldTime/FieldTime.html
+++ b/FieldTime/FieldTime.html
@@ -38,7 +38,8 @@
   </script>
   <!-- OpenCV.js for advanced preprocessing -->
   <script async src="https://docs.opencv.org/4.x/opencv.js" onload="cv['onRuntimeInitialized']=onOpenCvReady;"></script>
-  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
+  <!-- AWS SDK for Textract -->
+  <script src="https://sdk.amazonaws.com/js/aws-sdk-2.1376.0.min.js"></script>
 </head>
 <body>
   <div class="container">
@@ -115,6 +116,82 @@
       return thresh;
     }
 
+    // Convert canvas image to Uint8Array for Textract
+    function canvasToBytes(canvas) {
+      return new Promise(resolve => {
+        canvas.toBlob(blob => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(new Uint8Array(reader.result));
+          reader.readAsArrayBuffer(blob);
+        }, 'image/png');
+      });
+    }
+
+    // Parse Textract TABLE blocks into CSV
+    function textractToCSV(data) {
+      const blocks = data.Blocks || [];
+      const blockMap = {};
+      blocks.forEach(b => blockMap[b.Id] = b);
+      const tables = blocks.filter(b => b.BlockType === 'TABLE');
+      const csvRows = [];
+      tables.forEach(table => {
+        const cells = [];
+        (table.Relationships || []).forEach(rel => {
+          if (rel.Type === 'CHILD') {
+            rel.Ids.forEach(id => {
+              const cell = blockMap[id];
+              if (cell.BlockType === 'CELL') cells.push(cell);
+            });
+          }
+        });
+        const maxRow = Math.max(...cells.map(c => c.RowIndex), 0);
+        const rows = Array.from({length: maxRow}, () => []);
+        cells.forEach(cell => {
+          let text = '';
+          (cell.Relationships || []).forEach(rel => {
+            if (rel.Type === 'CHILD') {
+              rel.Ids.forEach(id => {
+                const word = blockMap[id];
+                if (word.BlockType === 'WORD') text += word.Text + ' ';
+              });
+            }
+          });
+          rows[cell.RowIndex - 1][cell.ColumnIndex - 1] = text.trim();
+        });
+        rows.forEach(row => csvRows.push(row.join(',')));
+      });
+      return csvRows.join('\n');
+    }
+
+    // Extract specific field regions and run Textract on each
+    async function extractFields(canvas, fields, textract) {
+      const results = {};
+      for (const [name, rect] of Object.entries(fields)) {
+        const ox = Math.round(canvas.width * rect.x);
+        const oy = Math.round(canvas.height * rect.y);
+        const ow = Math.round(canvas.width * rect.w);
+        const oh = Math.round(canvas.height * rect.h);
+        const off = document.createElement('canvas');
+        off.width = ow; off.height = oh;
+        const ctx = off.getContext('2d');
+        ctx.drawImage(canvas, ox, oy, ow, oh, 0, 0, ow, oh);
+
+        const bytes = await canvasToBytes(off);
+        try {
+          const data = await textract.detectDocumentText({
+            Document: { Bytes: bytes }
+          }).promise();
+          const lines = (data.Blocks || [])
+            .filter(b => b.BlockType === 'LINE')
+            .map(b => b.Text);
+          results[name] = lines.join(' ');
+        } catch (e) {
+          results[name] = '';
+        }
+      }
+      return results;
+    }
+
     ocrBtn.addEventListener('click', async () => {
       if (!window.cvReady) return alert('Processing library still loading');
       errorMsg.style.display = 'none';
@@ -131,57 +208,45 @@
       cv.imshow(canvas, proc);
       proc.delete();
 
-      // OCR per field
-      progressEl.value = 0;
-      const { createWorker, PSM } = Tesseract;
-      const worker = await createWorker();
-      await worker.setParameters({
-        preserve_interword_spaces: '1',
-        tessedit_pageseg_mode: PSM.AUTO // or PSM.SPARSE_TEXT
-      });
+      // Convert canvas to bytes for Textract
+      let bytes = await canvasToBytes(canvas);
 
-      const { data: { text } } = await worker.recognize(canvas, 'eng', {
-        // No logger function needed for Tesseract v5+
-      });
-      await worker.terminate();
+      // Configure AWS credentials (replace with your setup)
+      AWS.config.region = 'us-east-1';
+      // Credentials should be provided via Cognito Identity Pool or other secure method
+      // Example using environment variables: AWS.config.credentials = new AWS.Credentials('ACCESS_KEY','SECRET_KEY');
+
+      const textract = new AWS.Textract();
+      let data;
+      try {
+        data = await textract.analyzeDocument({
+          Document: { Bytes: bytes },
+          FeatureTypes: ['TABLES']
+        }).promise();
+      } catch (err) {
+        progressEl.style.display = 'none';
+        ocrBtn.textContent = 'Recognize Timesheet';
+        ocrBtn.disabled = false;
+        errorMsg.textContent = err.message || 'Textract failed';
+        errorMsg.style.display = 'block';
+        return;
+      }
 
       progressEl.value = 1;
 
-      // Show raw OCR output first
-      ocrResult.textContent = text;
+      const fieldsData = await extractFields(canvas, templateFields, textract);
+      const tableCsv = textractToCSV(data);
+      let csv = 'Field,Value\n';
+      Object.entries(fieldsData).forEach(([k,v]) => {
+        csv += `${k},${v}\n`;
+      });
+      csv += `\n${tableCsv}`;
+      ocrResult.textContent = csv;
       ocrResult.style.display = 'block';
 
-      // Wait a moment so user can see raw output before filtering
-      await new Promise(res => setTimeout(res, 1000));
-
-      // Split OCR text into lines
-      const lines = text.split('\n').map(line => line.trim()).filter(line => line.length > 0);
-
-      // Prepare CSV header
-      const csvRows = [];
-      csvRows.push('Code,Description,Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday');
-
-      // For each line, try to extract columns
-      for (const line of lines) {
-        // Try to match: code (numbers), description (words), then 7 numbers (hours)
-        // This regex assumes columns are separated by spaces or tabs
-        const match = line.match(/^(\d{3,6})\s+([A-Za-z0-9\s\/\-\(\)\.]+?)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)\s+(\d+(?:\.\d)?|\s)$/);
-        if (match) {
-          // Format as CSV row
-          const row = match.slice(1).map(v => `"${v.trim()}"`).join(',');
-          csvRows.push(row);
-        }
-      }
-
-      // Show and enable download
-      const csv = csvRows.join('\n');
       progressEl.style.display = 'none';
       ocrBtn.textContent = 'Recognize Timesheet';
       ocrBtn.disabled = false;
-
-      // Show filtered CSV below the raw output
-      ocrResult.textContent = text + '\n\n--- Filtered CSV ---\n' + csv;
-      ocrResult.style.display = 'block';
       downloadCsv.style.display = 'block';
       downloadCsv.onclick = () => {
         const blob = new Blob([csv], { type: 'text/csv' });
@@ -189,8 +254,6 @@
         const a = document.createElement('a'); a.href = url; a.download = 'timesheet_hours.csv'; a.click(); URL.revokeObjectURL(url);
       };
     });
-
-    Tesseract.setLogging(true);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove Tesseract.js and load AWS SDK in the timesheet page
- convert canvas to byte array and call Textract `analyzeDocument`
- parse table blocks into CSV output for download
- crop predefined template regions and run Textract on each to label field values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f0b688e0832fa19c860c26468d7b